### PR TITLE
feat: update Skills, About Me and README from CV

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,37 +34,52 @@ Make sure you have Node.js (which includes npm) installed on your machine.
     ```sh
     cd Portfolio
     ```
-3.  Install NPM packages
+3.  Install dependencies
     ```sh
-    npm install
+    make install
     ```
+
+### Available Commands
+
+All common tasks are wrapped by the `Makefile`. Run `make help` to list them at any time.
+
+| Command | Description |
+|---|---|
+| `make dev` | Start dev server at `http://localhost:4321` |
+| `make build` | Build static site to `dist/` |
+| `make preview` | Build then serve `dist/` locally |
+| `make test` | Run tests once |
+| `make test-watch` | Run tests in watch mode |
+| `make test-ui` | Run tests with browser UI |
+| `make install` | Install dependencies |
+| `make clean` | Remove `dist/` build output |
 
 ### Development
 
 To start the development server:
 
 ```sh
-npm run dev
+make dev
 ```
 
-This will start a local development server, usually at `http://localhost:4321`.
+This will start a local development server at `http://localhost:4321`.
 
 ### Build
 
 To build the project for production:
 
 ```sh
-npm run build
+make build
 ```
 
-This command will generate a `dist/` directory with all the static assets.
+This generates a `dist/` directory with all the static assets.
 
 ### Preview
 
 To preview the production build locally:
 
 ```sh
-npm run preview
+make preview
 ```
 
 ## Project Structure
@@ -101,7 +116,7 @@ graph TD
 
 ## Deployment
 
-After running `npm run build`, the `dist/` directory contains the static files ready for deployment. You can deploy this directory to any static site hosting service (e.g., Netlify, Vercel, GitHub Pages).
+After running `make build`, the `dist/` directory contains the static files ready for deployment. You can deploy this directory to any static site hosting service (e.g., Netlify, Vercel, GitHub Pages).
 
 ## License
 

--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -20,10 +20,12 @@ const locale = Astro.currentLocale;
             : 'Specializing in the intersection of Generative AI infrastructure, FinOps-driven cloud governance, and IaC-powered DevOps — from orchestrating 500+ Cloud Run services at P&G to leading GCP compliance and migration workstreams for RBC\'s 15M+ global clients. Recognized for architecting cost-optimized, AI-augmented platforms that bridge Big Data engineering and automated governance to deliver measurable business impact at enterprise scale.'}
         </p>
         <ul class="flex flex-wrap gap-4 mt-6">
-          <li class="bg-brand-cloud/20 text-brand-cloud py-1 px-3 rounded-full text-sm font-semibold">Cloud Architecture</li>
-          <li class="bg-brand-devops/20 text-brand-devops py-1 px-3 rounded-full text-sm font-semibold">DevOps</li>
-          <li class="bg-brand-data/20 text-brand-data py-1 px-3 rounded-full text-sm font-semibold">Big Data</li>
-          <li class="bg-brand-python/20 text-brand-python py-1 px-3 rounded-full text-sm font-semibold">Python</li>
+          <li class="bg-brand-cloud/20 text-brand-cloud py-1 px-3 rounded-full text-sm font-semibold">{locale === 'es' ? 'Arquitectura Cloud' : 'Cloud Architecture'}</li>
+          <li class="bg-brand-python/20 text-brand-python py-1 px-3 rounded-full text-sm font-semibold">{locale === 'es' ? 'IA Generativa' : 'AI & Generative AI'}</li>
+          <li class="bg-secondary/20 text-secondary py-1 px-3 rounded-full text-sm font-semibold">{locale === 'es' ? 'Gobernanza & FinOps' : 'Cloud Governance & FinOps'}</li>
+          <li class="bg-brand-devops/20 text-brand-devops py-1 px-3 rounded-full text-sm font-semibold">DevOps & CI/CD</li>
+          <li class="bg-brand-data/20 text-brand-data py-1 px-3 rounded-full text-sm font-semibold">{locale === 'es' ? 'Big Data' : 'Big Data'}</li>
+          <li class="bg-primary/20 text-primary py-1 px-3 rounded-full text-sm font-semibold">{locale === 'es' ? 'APIs & Apigee X' : 'Apigee X & APIs'}</li>
         </ul>
       </div>
     </div>

--- a/src/components/Skills.astro
+++ b/src/components/Skills.astro
@@ -1,35 +1,43 @@
 ---
 const locale = Astro.currentLocale;
 const skills = locale === 'es' ? {
-  'Plataformas en la Nube': ['AWS', 'Azure', 'GCP'],
-  'Herramientas DevOps': ['Kubernetes', 'Docker', 'Terraform', 'Jenkins', 'Git', 'CI/CD'],
-  'Big Data': ['Apache Spark', 'Apache Hadoop', 'Apache Kafka', 'Airflow'],
-  'Lenguajes': ['Python', 'Bash', 'SQL', 'JavaScript'],
-  'Bases de Datos': ['PostgreSQL', 'MySQL', 'MongoDB', 'Redis'],
-  'Otros': ['Linux', 'Redes', 'Seguridad', 'Metodologías Ágiles']
+  'Plataformas en la Nube': ['GCP', 'AWS', 'Microsoft Azure'],
+  'IA & IA Generativa': ['Vertex AI', 'AWS Bedrock', 'AWS SageMaker', 'LangChain', 'BigQuery ML', 'Prompt Engineering', 'Foundation Models'],
+  'DevOps & CI/CD': ['GitHub Actions', 'GitLab CI', 'Jenkins', 'Docker', 'Terraform', 'Bitbucket Pipelines', 'IaC a Escala'],
+  'Big Data & Datos Distribuidos': ['BigQuery', 'Dataflow', 'Apache Beam', 'Pub/Sub', 'Dataproc', 'Apache Airflow', 'Cloud Composer', 'dbt'],
+  'Gobernanza Cloud & FinOps': ['FinOps Framework', 'CloudZero', 'Cloud Armor', 'Optimización de Costos', 'Cumplimiento Multi-Cloud', 'Diseño HA/DR'],
+  'API & Desarrollo': ['Apigee X', 'FastAPI', 'Flask', 'SpringBoot', 'Go (Golang)'],
+  'Lenguajes': ['Python', 'Go', 'Java', 'SQL'],
+  'Bases de Datos': ['PostgreSQL', 'Cloud SQL', 'AWS RDS']
 } : {
-  'Cloud Platforms': ['AWS', 'Azure', 'GCP'],
-  'DevOps Tools': ['Kubernetes', 'Docker', 'Terraform', 'Jenkins', 'Git', 'CI/CD'],
-  'Big Data': ['Apache Spark', 'Apache Hadoop', 'Apache Kafka', 'Airflow'],
-  'Languages': ['Python', 'Bash', 'SQL', 'JavaScript'],
-  'Databases': ['PostgreSQL', 'MySQL', 'MongoDB', 'Redis'],
-  'Other': ['Linux', 'Networking', 'Security', 'Agile Methodologies']
+  'Cloud Platforms': ['GCP', 'AWS', 'Microsoft Azure'],
+  'AI & Generative AI': ['Vertex AI', 'AWS Bedrock', 'AWS SageMaker', 'LangChain', 'BigQuery ML', 'Prompt Engineering', 'Foundation Models'],
+  'DevOps & CI/CD': ['GitHub Actions', 'GitLab CI', 'Jenkins', 'Docker', 'Terraform', 'Bitbucket Pipelines', 'IaC at Scale'],
+  'Distributed Systems & Big Data': ['BigQuery', 'Dataflow', 'Apache Beam', 'Pub/Sub', 'Dataproc', 'Apache Airflow', 'Cloud Composer', 'dbt'],
+  'Cloud Governance & FinOps': ['FinOps Framework', 'CloudZero', 'Cloud Armor', 'Cost Optimization', 'Multi-Cloud Compliance', 'HA/DR Design'],
+  'API & Application Dev': ['Apigee X', 'FastAPI', 'Flask', 'SpringBoot', 'Go (Golang)'],
+  'Languages': ['Python', 'Go', 'Java', 'SQL'],
+  'Databases': ['PostgreSQL', 'Cloud SQL', 'AWS RDS']
 };
 
 const categoryColors = locale === 'es' ? {
   'Plataformas en la Nube': 'brand-cloud',
-  'Herramientas DevOps': 'brand-devops',
-  'Big Data': 'brand-data',
+  'IA & IA Generativa': 'brand-python',
+  'DevOps & CI/CD': 'brand-devops',
+  'Big Data & Datos Distribuidos': 'brand-data',
+  'Gobernanza Cloud & FinOps': 'secondary',
+  'API & Desarrollo': 'primary',
   'Lenguajes': 'brand-python',
-  'Bases de Datos': 'primary',
-  'Otros': 'secondary'
+  'Bases de Datos': 'primary'
 } : {
   'Cloud Platforms': 'brand-cloud',
-  'DevOps Tools': 'brand-devops',
-  'Big Data': 'brand-data',
+  'AI & Generative AI': 'brand-python',
+  'DevOps & CI/CD': 'brand-devops',
+  'Distributed Systems & Big Data': 'brand-data',
+  'Cloud Governance & FinOps': 'secondary',
+  'API & Application Dev': 'primary',
   'Languages': 'brand-python',
-  'Databases': 'primary',
-  'Other': 'secondary'
+  'Databases': 'primary'
 };
 ---
 


### PR DESCRIPTION
## Summary

Updates the portfolio to reflect the current Areas of Expertise from the updated CV.

## Changes

### Skills.astro — Technical Skills
Restructured from 6 to 8 categories mirroring the CV:
- NEW: AI & Generative AI (Vertex AI, Bedrock, SageMaker, LangChain, BigQuery ML, Prompt Engineering)
- NEW: Cloud Governance & FinOps (FinOps Framework, CloudZero, Cloud Armor, Cost Optimization)
- Updated: DevOps & CI/CD (GitHub Actions, GitLab CI, Jenkins, Docker, Terraform, Bitbucket Pipelines)
- Updated: Distributed Systems & Big Data (BigQuery, Dataflow, Apache Beam, Pub/Sub, Dataproc, Airflow, dbt)
- Updated: API & Application Dev (Apigee X, FastAPI, Flask, SpringBoot, Go)
- Updated: Languages (Python, Go, Java, SQL)
- Updated: Databases (PostgreSQL, Cloud SQL, AWS RDS)
Both EN and ES locales updated.

### About.astro — About Me Skill Pills
Updated from 4 static pills to 6 bilingual pills:
Cloud Architecture, AI & Generative AI, Cloud Governance & FinOps, DevOps & CI/CD, Big Data, Apigee X & APIs

### README.md — Documentation
- Replaced all npm run commands with make equivalents
- Added Available Commands quick-reference table
- Updated Installation, Development, Build, Preview, and Deployment sections
